### PR TITLE
set MaxHotkeysPerInterval to 350

### DIFF
--- a/alt-ime-ahk.ahk
+++ b/alt-ime-ahk.ahk
@@ -9,6 +9,9 @@
 
 #Include IME.ahk
 
+; AutoHotKey設定
+#MaxHotkeysPerInterval 350
+
 ; 主要なキーを HotKey に設定し、何もせずパススルーする
 *~a::
 *~b::


### PR DESCRIPTION
Razer Synapseや、キーカスタマイズ系のユーティリティーを併用しているときに、AutoHotKeyのデフォルトで受け付けるキーインプットを超えてキーイベントが発火した時に警告エラーダイアログがでるのですが、これがデフォルトの設定だとかなり頻繁に出現するので許容するイベント数をデフォルトの70(未設定時)から350に変更しました。

手元で再現する環境でテストした限り350だと過剰にWarningが出ることはなさそうです。