### PR TITLE
Fix vk07 to vkFF

### DIFF
--- a/alt-ime-ahk.ahk
+++ b/alt-ime-ahk.ahk
@@ -108,8 +108,8 @@
     Return
 
 ; 上部メニューがアクティブになるのを抑制
-*~LAlt::Send {Blind}{vk07}
-*~RAlt::Send {Blind}{vk07}
+*~LAlt::Send {Blind}{vkFF}
+*~RAlt::Send {Blind}{vkFF}
 
 ; 左 Alt 空打ちで IME を OFF
 LAlt up::


### PR DESCRIPTION
https://github.com/karakaram/alt-ime-ahk/issues/20 と同じ症状が私の環境でも再発したので `vk07` を `vkFF` に修正いたしました。
以下、ご確認のほどよろしくお願いいたします。

私の方で動作確認をしてあります。

`vkFF` への修正については
https://www.autohotkey.com/docs/commands/_MenuMaskKey.htm#Remarks に

> vkFF is no mapping.

と記載があるので、おそらく現時点では使用されていないキーだと思われます。

また、 @nekocodeX さんの https://github.com/nekocodeX/alt-ime-ahk-mod でも同様の修正がされており、そちらも私の方で試して問題がなさそうなことを確認しています。