### PR TITLE
単一Altキーを短い間隔で2回連続押した場合には、キーコードの発行を抑制しない。

### DIFF
--- a/alt-ime-ahk.ahk
+++ b/alt-ime-ahk.ahk
@@ -108,15 +108,24 @@
     Return
 
 ; 上部メニューがアクティブになるのを抑制
-; ただし、ダブルタップ時(200ms以内)は例外(同一キー制約をつけたいがうまく行かない)
-;     If (A_PriorHotKey == A_ThisHotKey and 200 < A_TimeSincePriorHotkey )
-
+; ただし、ダブルタップ時(200ms以内)は単altキーを入力
 *~LAlt::
-*~RAlt::
-    if ( 200 < A_TimeSincePriorHotkey )
+    If (A_PriorHotKey == "RAlt up" and 200 > A_TimeSincePriorHotkey )
     {
+        Send {LAlt}
+    }else{
          Send {Blind}{vk07}
     }
+    Return  
+
+*~RAlt::
+    If (A_PriorHotKey == "RAlt up" and 200 > A_TimeSincePriorHotkey )
+    {
+        Send {RAlt}
+    }else{
+         Send {Blind}{vk07}
+    }
+    Return
  
 ; 左 Alt 空打ちで IME を OFF
 LAlt up::

--- a/alt-ime-ahk.ahk
+++ b/alt-ime-ahk.ahk
@@ -108,9 +108,21 @@
     Return
 
 ; 上部メニューがアクティブになるのを抑制
-*~LAlt::Send {Blind}{vk07}
-*~RAlt::Send {Blind}{vk07}
+; ただし、ダブルタップ時(200ms以内)は例外(同一キー制約をつけたいがうまく行かない)
+;     If (A_PriorHotKey == A_ThisHotKey and A_TimeSincePriorHotkey < 200)
 
+*~LAlt::
+    If ( 200 < A_TimeSincePriorHotkey )
+    {
+        Send {Blind}{vk07}
+    }
+
+*~RAlt::
+    If ( 200 < A_TimeSincePriorHotkey )
+    {
+        Send {Blind}{vk07}
+    }
+ 
 ; 左 Alt 空打ちで IME を OFF
 LAlt up::
     if (A_PriorHotkey == "*~LAlt")

--- a/alt-ime-ahk.ahk
+++ b/alt-ime-ahk.ahk
@@ -108,22 +108,22 @@
     Return
 
 ; 上部メニューがアクティブになるのを抑制
-; ただし、ダブルタップ時(200ms以内)は単altキーを入力
+; ただし、200ms以内の2回押し時は抑制しない
 *~LAlt::
-    If (A_PriorHotKey == "RAlt up" and 200 > A_TimeSincePriorHotkey )
+    If ( A_PriorHotKey == "LAlt up" and 200 > A_TimeSincePriorHotkey )
     {
-        Send {LAlt}
-    }else{
-         Send {Blind}{vk07}
+        Send {Blind}{Alt}
+    } else {
+        Send {Blind}{vk07}
     }
     Return  
 
 *~RAlt::
-    If (A_PriorHotKey == "RAlt up" and 200 > A_TimeSincePriorHotkey )
+    If ( A_PriorHotKey == "RAlt up" and 200 > A_TimeSincePriorHotkey )
     {
-        Send {RAlt}
-    }else{
-         Send {Blind}{vk07}
+        Send {Blind}{Alt}
+    } else {
+        Send {Blind}{vk07}
     }
     Return
  

--- a/alt-ime-ahk.ahk
+++ b/alt-ime-ahk.ahk
@@ -109,18 +109,13 @@
 
 ; 上部メニューがアクティブになるのを抑制
 ; ただし、ダブルタップ時(200ms以内)は例外(同一キー制約をつけたいがうまく行かない)
-;     If (A_PriorHotKey == A_ThisHotKey and A_TimeSincePriorHotkey < 200)
+;     If (A_PriorHotKey == A_ThisHotKey and 200 < A_TimeSincePriorHotkey )
 
 *~LAlt::
-    If ( 200 < A_TimeSincePriorHotkey )
-    {
-        Send {Blind}{vk07}
-    }
-
 *~RAlt::
-    If ( 200 < A_TimeSincePriorHotkey )
+    if ( 200 < A_TimeSincePriorHotkey )
     {
-        Send {Blind}{vk07}
+         Send {Blind}{vk07}
     }
  
 ; 左 Alt 空打ちで IME を OFF

--- a/alt-ime-ahk.ahk
+++ b/alt-ime-ahk.ahk
@@ -114,7 +114,7 @@
     {
         Send {Blind}{Alt}
     } else {
-        Send {Blind}{vk07}
+        Send {Blind}{vkFF}
     }
     Return  
 
@@ -123,7 +123,7 @@
     {
         Send {Blind}{Alt}
     } else {
-        Send {Blind}{vk07}
+        Send {Blind}{vkFF}
     }
     Return
  


### PR DESCRIPTION
単一Altキーを短い間隔で2回連続押した場合には、キーコードの発行を抑制しない。

Alt キーで、メニューが表示されるソフトウエアなどで、Alt キーが押せなくなってしまうので、2回押し(200ms以内の間隔)で Alt キーを入力できるようにするため。

---
ずっと alt-ime-ahk にお世話になっておりました。
このソフトウエアのおかげで、日本語キーボードより日本語が打ちやすくなり、大変重宝しております。
ただ、本来の alt キー単押しが常に抑制されてしまうので、どうにかこれを活かしたいと思い、2回連続で押したときには、本来の alt キーを抑制しない改変を提案致します。
よろしくお願い致します。