### PR TITLE
Make `alt-ime-ahk.ahk` work with AHK v2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "IMEv2.ahk"]
+	path = IMEv2.ahk
+	url = git@github.com:k-ayaki/IMEv2.ahk.git

--- a/alt-ime-ahk-v2.ahk
+++ b/alt-ime-ahk-v2.ahk
@@ -1,0 +1,136 @@
+#Requires AutoHotkey v2.0
+
+; 左右 Alt キーの空打ちで IME の OFF/ON を切り替える
+;
+; 左 Alt キーの空打ちで IME を「英数」に切り替え
+; 右 Alt キーの空打ちで IME を「かな」に切り替え
+; Alt キーを押している間に他のキーを打つと通常の Alt キーとして動作
+;
+; Author:     karakaram   http://www.karakaram.com/alt-ime-on-off
+
+#Include IMEv2.ahk/IMEv2.ahk
+
+; Razer Synapseなど、キーカスタマイズ系のツールを併用しているときのエラー対策
+A_MaxHotkeysPerInterval := 350
+
+; 主要なキーを HotKey に設定し、何もせずパススルーする
+*~a::
+*~b::
+*~c::
+*~d::
+*~e::
+*~f::
+*~g::
+*~h::
+*~i::
+*~j::
+*~k::
+*~l::
+*~m::
+*~n::
+*~o::
+*~p::
+*~q::
+*~r::
+*~s::
+*~t::
+*~u::
+*~v::
+*~w::
+*~x::
+*~y::
+*~z::
+*~1::
+*~2::
+*~3::
+*~4::
+*~5::
+*~6::
+*~7::
+*~8::
+*~9::
+*~0::
+*~F1::
+*~F2::
+*~F3::
+*~F4::
+*~F5::
+*~F6::
+*~F7::
+*~F8::
+*~F9::
+*~F10::
+*~F11::
+*~F12::
+*~`::
+*~~::
+*~!::
+*~@::
+*~#::
+*~$::
+*~%::
+*~^::
+*~&::
+*~*::
+*~(::
+*~)::
+*~-::
+*~_::
+*~=::
+*~+::
+*~[::
+*~{::
+*~]::
+*~}::
+*~\::
+*~|::
+*~;::
+*~'::
+*~"::
+*~,::
+*~<::
+*~.::
+*~>::
+*~/::
+*~?::
+*~Esc::
+*~Tab::
+*~Space::
+*~Left::
+*~Right::
+*~Up::
+*~Down::
+*~Enter::
+*~PrintScreen::
+*~Delete::
+*~Home::
+*~End::
+*~PgUp::
+*~PgDn::
+{
+    Return
+}
+
+; 上部メニューがアクティブになるのを抑制
+*~LAlt::Send ("{Blind}{vk07}")
+*~RAlt::Send ("{Blind}{vk07}")
+
+; 左 Alt 空打ちで IME を OFF
+LAlt up::
+{
+    if (A_PriorHotkey == "*~LAlt")
+    {
+        IME_SET(0)
+    }
+    Return
+}
+
+; 右 Alt 空打ちで IME を ON
+RAlt up::
+{
+    if (A_PriorHotkey == "*~RAlt")
+    {
+        IME_SET(1)
+    }
+    Return
+}


### PR DESCRIPTION
`alt-ime-ahk.ahk`をAutoHotKey v2.0に対応させました。

旧版との互換性維持のため、v2.0対応版を[alt-ime-ahk-v2.ahk](alt-ime-ahk-v2.ahk)として新しいファイルに分離しています。

`IME.ahk`については、既に対応させてくださっていた https://github.com/k-ayaki/IMEv2.ahk のコードをsubmoduleとして取り込む形で対応しています。